### PR TITLE
Fixed -stdlib=libc++ error with g++ 4.8.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,9 +37,8 @@ file(
 
 ADD_DEFINITIONS(
   -std=c++11
-  -stdlib=libc++
 )
-set(CMAKE_CXX_FLAGS "-std=c++11 -stdlib=libc++")
+set(CMAKE_CXX_FLAGS "-std=c++11")
 
 # Add the libraries
 add_library(${ANAX_LIBRARY_NAME} SHARED ${ANAX_LIBRARY_SOURCES})


### PR DESCRIPTION
When executing make if you are using g++ 4.8.1 you get the error "c++: error: unrecognized command line option ‘-stdlib=libc++’" This fixes that.
