### PR TITLE
Fix variadic template to work with perfect forwarding

### DIFF
--- a/include/anax/Entity.hpp
+++ b/include/anax/Entity.hpp
@@ -246,7 +246,7 @@ namespace anax
 	template <typename T, typename... Args>
 	T& Entity::addComponent(Args&&... args)
 	{
-		return addComponent<T>(new T{args...});
+		return addComponent<T>(new T{std::forward<Args>(args)...});
 	}
 	
 #endif // ANAX_USE_VARIADIC_TEMPLATES


### PR DESCRIPTION
The variadic template Entity::addComponent<T,Args...> does not forward rval references to Component constructors. The fix is to use std::forward<Args>.
