### PR TITLE
Fix the way PlayerInputSystem removes a listener in examples

### DIFF
--- a/examples/common/include/Systems/PlayerInputSystem.hpp
+++ b/examples/common/include/Systems/PlayerInputSystem.hpp
@@ -29,6 +29,8 @@
 #ifndef ANAX_EXAMPLES_MOVEMENT_PLAYERINPUTSYSTEM_HPP
 #define ANAX_EXAMPLES_MOVEMENT_PLAYERINPUTSYSTEM_HPP
 
+#include <algorithm>
+
 #include <anax/System.hpp>
 
 #include <Components/PlayerComponent.hpp>


### PR DESCRIPTION
removeListener was using std::remove which is a function that performs file
operations. (http://www.cplusplus.com/reference/cstdio/remove/)
This caused the examples to not compile.
```
In file included from /home/elkhadiy/Projects/SFML/anax/examples/common/src/Systems/PlayerInputSystem.cpp:29:0:
/home/elkhadiy/Projects/SFML/anax/examples/common/include/Systems/PlayerInputSystem.hpp: In member function ‘void PlayerInputSystem::removeListener(PlayerInputSystem::Listener*)’:
/home/elkhadiy/Projects/SFML/anax/examples/common/include/Systems/PlayerInputSystem.hpp:52:125: error: cannot convert ‘std::vector<PlayerInputSystem::Listener*>::iterator {aka __gnu_cxx::__norma
l_iterator<PlayerInputSystem::Listener**, std::vector<PlayerInputSystem::Listener*> >}’ to ‘const char*’ for argument ‘1’ to ‘int remove(const char*)’
     void removeListener(Listener* listener) { m_listeners.erase(std::remove(m_listeners.begin(), m_listeners.end(), listener), m_listeners.end()); }
                                                                                                                             ^
examples/CMakeFiles/anax_common.dir/build.make:182: recipe for target 'examples/CMakeFiles/anax_common.dir/common/src/Systems/PlayerInputSystem.cpp.o' failed
make[2]: *** [examples/CMakeFiles/anax_common.dir/common/src/Systems/PlayerInputSystem.cpp.o] Error 1
CMakeFiles/Makefile2:282: recipe for target 'examples/CMakeFiles/anax_common.dir/all' failed
make[1]: *** [examples/CMakeFiles/anax_common.dir/all] Error 2
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2
```
The fix replaces std::remove with std::find which looks for an element in
m_listeners equal to listener and returns an iterator to it so that erase
can remove it. (http://www.cplusplus.com/reference/algorithm/find/)