### PR TITLE
Move the CMake-generated config header into the build tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,11 @@ if(INSTALL_HEADERS)
             DESTINATION .
             FILES_MATCHING PATTERN "*.hpp"
            )
+    install(
+            DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include
+            DESTINATION .
+            FILES_MATCHING PATTERN "*.hpp"
+           )
 endif()
 
 # Set properties for the library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,10 +56,11 @@ set(ANAX_MAX_AMOUNT_OF_COMPONENTS 64 CACHE INTEGER "The maximum amount of compon
 
 
 # set up the configure file for the library
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/anax/Config.hpp.inl ${CMAKE_CURRENT_SOURCE_DIR}/include/anax/Config.hpp)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/anax/Config.hpp.inl ${CMAKE_CURRENT_BINARY_DIR}/include/anax/Config.hpp)
 
 # Add include directories
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 
 # Determine if we're building a shared (dynamic) library
 # And set appropriate suffixes for the executables


### PR DESCRIPTION
The current setup of `configure_file` creates its header directly in the source tree, which dirties the source tree (an annoyance if using Anax as a git submodule), and makes trouble if using multiple build configurations side by side in different build trees.