### PR TITLE
Making isValid More Useful

### DIFF
--- a/src/anax/World.cpp
+++ b/src/anax/World.cpp
@@ -114,7 +114,7 @@ namespace anax
 
     bool World::isActivated(const Entity& entity) const
     {
-        if( isValid(entity) )
+        if(isValid(entity))
             return m_entityAttributes.attributes[entity.getId().index].activated;
         else
             return false;

--- a/src/anax/World.cpp
+++ b/src/anax/World.cpp
@@ -114,9 +114,10 @@ namespace anax
 
     bool World::isActivated(const Entity& entity) const
     {
-        ANAX_ASSERT(isValid(entity), "invalid entity passed to isActivated");
-
-        return m_entityAttributes.attributes[entity.getId().index].activated;
+        if( isValid(entity) )
+            return m_entityAttributes.attributes[entity.getId().index].activated;
+        else
+            return false;
     }
 
     bool World::isValid(const anax::Entity &entity) const

--- a/src/anax/detail/EntityIdPool.cpp
+++ b/src/anax/detail/EntityIdPool.cpp
@@ -69,14 +69,18 @@ namespace anax
 
         Entity::Id EntityIdPool::get(std::size_t index) const
         {
-            ANAX_ASSERT(index < m_counts.size(), "Entity index is out of range");
-            ANAX_ASSERT(!(m_counts[index] == 0), "Entity ID does not exist");
-            return Entity::Id{index, m_counts[index]};
+            if( index < m_counts.size() )
+                return Entity::Id(index, m_counts[index]);
+            else
+                return Entity::Id{index, 0};
         }
 
         bool EntityIdPool::isValid(Entity::Id id) const
         {
-            return id.counter == m_counts[id.index];
+            if( id.index >= m_counts.size() )
+                return false;
+            else
+                return (id.counter == m_counts[id.index]) && (id.counter > 0);
         }
 
         std::size_t EntityIdPool::getSize() const
@@ -94,8 +98,6 @@ namespace anax
             m_counts.clear();
             m_freeList.clear();
             m_nextId = 0;
-
-            m_counts.resize(m_defaultPoolSize);
         }
     }
 }

--- a/src/anax/detail/EntityIdPool.cpp
+++ b/src/anax/detail/EntityIdPool.cpp
@@ -69,15 +69,15 @@ namespace anax
 
         Entity::Id EntityIdPool::get(std::size_t index) const
         {
-            if( index < m_counts.size() )
-                return Entity::Id(index, m_counts[index]);
+            if(index < m_counts.size())
+                return Entity::Id{index, m_counts[index]};
             else
                 return Entity::Id{index, 0};
         }
 
         bool EntityIdPool::isValid(Entity::Id id) const
         {
-            if( id.index >= m_counts.size() )
+            if(id.index >= m_counts.size())
                 return false;
             else
                 return (id.counter == m_counts[id.index]) && (id.counter > 0);

--- a/tests/Test_Entities.cpp
+++ b/tests/Test_Entities.cpp
@@ -67,7 +67,7 @@ using namespace anax;
 //      ✓ Removing a component => does hasComponent return false?
 //      ✓ Removing all components => does hasComponent return false?
 // 6. Retrieving an entity via index
-//      ✓ Invalid index => assertion occurs?
+//      ✓ Invalid index => invalid entity returned?
 //      ✓  Valid index => appropriate entity returned?
 //      ✓ Multiple entities added/removed => appropriate entity returned?
 
@@ -414,7 +414,7 @@ const lest::test specification[] =
         anax::World world;
 
         auto e = world.createEntity();
-        EXPECT_THROWS_AS(world.getEntity(-1), anax::TestException);
+        EXPECT(!(world.getEntity(-1).isValid()));
     }
 };
 


### PR DESCRIPTION
The isValid function can hit assert statements for several conditions. This can make anax a bit hostile to newcomers as a test like 'isValid' is not often expected to fail. On Windows, assert does not throw an exception that can be caught, so returning an invalid ID from EntityIdPool::get is more useful at run-time.

Also fixed a bug in clearing the m_counts vector. This was causing a crash after calling World::clear, because the m_counts vector would suddenly be larger than other vectors that are expected to be the same size.

Updated the unit tests to account for an invalid get returning an invalid entity instead of crashing.