### PR TITLE
Forbidding activate/deactivate/killEntity while refresh()

### DIFF
--- a/include/anax/World.hpp
+++ b/include/anax/World.hpp
@@ -178,6 +178,13 @@ namespace anax
         Entity getEntity(std::size_t index);
 
     private:
+	/// World is currenctly refreshing and blocking calls that might interfere 
+	/// with that.
+	bool m_refreshing = false;
+
+	/// \return True if world is currently refreshing.
+	/// \note This checks if world is currently refreshing.
+	bool isRefreshing() const;
 
         /// Systems attached with the world.
         SystemArray m_systems;

--- a/src/anax/World.cpp
+++ b/src/anax/World.cpp
@@ -83,6 +83,8 @@ namespace anax
 
     void World::killEntity(Entity& entity)
     {
+        ANAX_ASSERT(!isRefreshing(), "cannot kill entities while refreshing");
+
         // deactivate the entity
         deactivateEntity(entity);
 
@@ -101,6 +103,7 @@ namespace anax
     void World::activateEntity(Entity& entity)
     {
         ANAX_ASSERT(isValid(entity), "invalid entity tried to be activated");
+        ANAX_ASSERT(!isRefreshing(), "cannot activate entities while refreshing");
 
         m_entityCache.activated.push_back(entity);
     }
@@ -108,6 +111,7 @@ namespace anax
     void World::deactivateEntity(Entity& entity)
     {
         ANAX_ASSERT(isValid(entity), "invalid entity tried to be deactivated");
+        ANAX_ASSERT(!isRefreshing(), "cannot deactivate entities while refreshing");
 
         m_entityCache.deactivated.push_back(entity);
     }
@@ -125,8 +129,15 @@ namespace anax
         return m_entityIdPool.isValid(entity.getId());
     }
 
+    bool World::isRefreshing() const
+    {
+        return m_refreshing;
+    }
+
     void World::refresh()
     {
+	m_refreshing = true;
+
         // go through all the activated entities from last call to refresh
         for(auto& entity : m_entityCache.activated)
         {
@@ -198,6 +209,8 @@ namespace anax
 
         // clear the temp cache
         m_entityCache.clearTemp();
+
+	m_refreshing = false;
     }
 
     void World::clear()


### PR DESCRIPTION
Quick idea for parts of #82 and #77 . Probably not best solution, ugly bool in there.