### PR TITLE
fix(cmake): i386 arch deprecated on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ set_target_properties(${ANAX_LIBRARY_NAME} PROPERTIES
                      )
 
 if(APPLE)
-    set_target_properties(${ANAX_LIBRARY_NAME} PROPERTIES OSX_ARCHITECTURES "i386;x86_64;")
+    set_target_properties(${ANAX_LIBRARY_NAME} PROPERTIES OSX_ARCHITECTURES "x86_64;")
 endif()
 
 # Library files


### PR DESCRIPTION
* `i386` architecture has been deprecated and building it for 32-bit gives error on linker. I think it's wise to remove it.